### PR TITLE
fix: check for NaN BigNumber (#244)

### DIFF
--- a/packages/common-resources/static-resources/src/utils/util.ts
+++ b/packages/common-resources/static-resources/src/utils/util.ts
@@ -113,7 +113,7 @@ export const getValuePrecisionThousand = (value: number | string | BigNumber | u
     const isPrice = option?.isPrice
     const isAbbreviate = option?.isAbbreviate
     const abbreviate = (option?.abbreviate) ?? 6
-    if ((!value || !Number.isFinite(Number(value)) || Number(value) === 0) && !BigNumber.isBigNumber(value)) {
+    if (((!value || !Number.isFinite(Number(value)) || Number(value) === 0) && !BigNumber.isBigNumber(value)) || (BigNumber.isBigNumber(value) && value.isNaN())){
         return '0.00'
     }
     let result: any = value;


### PR DESCRIPTION
Fix for #244 

`value` is coming across as a NaN BigNumber:

 `BigNumber {s: null, e: null, c: null}`

As a result, the UI shows NaN.  This change performs an additional check in the if statement to determine if `value` is BigNumber && NaN and returns 0.00

