### PR TITLE
fixed misspelling of Available

### DIFF
--- a/packages/component-lib/src/components/tradePanel/components/AmmWrap/AmmWithdraw.tsx
+++ b/packages/component-lib/src/components/tradePanel/components/AmmWrap/AmmWithdraw.tsx
@@ -191,7 +191,7 @@ export const AmmWithdrawWrap = <T extends AmmExitData<C extends IBData<I> ? C : 
             }, {
               value: 75, label: ''
             }, {
-              value: 100, label: t('labelAvaiable:') + '100%'
+              value: 100, label: t('labelAvailable:') + '100%'
             }]} handleChanged={onPercentage}/>
           </Box>
 

--- a/packages/component-lib/src/components/tradePanel/components/Interface.ts
+++ b/packages/component-lib/src/components/tradePanel/components/Interface.ts
@@ -161,7 +161,7 @@ export type WithdrawExtendProps<T, I, C> = {
   isThumb?: boolean;
   addressDefault: string;
   accAddr: string;
-  isNotAvaiableAddress: boolean;
+  isNotAvailableAddress: boolean;
   realAddr?: string;
   isAddressCheckLoading: boolean;
   isCFAddress: boolean;

--- a/packages/component-lib/src/components/tradePanel/components/WithdrawWrap.tsx
+++ b/packages/component-lib/src/components/tradePanel/components/WithdrawWrap.tsx
@@ -64,7 +64,7 @@ export const WithdrawWrap = <
   withdrawI18nKey,
   addressDefault,
   accAddr,
-  isNotAvaiableAddress,
+  isNotAvailableAddress,
   withdrawTypes = WithdrawTypes,
   withdrawType,
   chargeFeeTokenList = [],
@@ -328,7 +328,7 @@ export const WithdrawWrap = <
             ""
           )}
           <Box marginLeft={1 / 2}>
-            {isNotAvaiableAddress ? (
+            {isNotAvailableAddress ? (
               <Typography
                 color={"var(--color-error)"}
                 fontSize={14}

--- a/packages/web3-provider/src/walletServices.ts
+++ b/packages/web3-provider/src/walletServices.ts
@@ -5,7 +5,7 @@ import { Commands, ErrorType, ProcessingType } from "./command";
 //TODO typeof account State
 const subject = new Subject<{ status: keyof typeof Commands; data: any }>();
 
-const AvaiableNetwork = [1, 5];
+const AvailableNetwork = [1, 5];
 export const walletServices = {
   subject,
   sendProcess: async (type: keyof typeof ProcessingType, props?: any) => {
@@ -32,7 +32,7 @@ export const walletServices = {
           provider,
           accounts,
           chainId:
-            AvaiableNetwork.findIndex((i) => i == Number(chainId)) !== -1
+            AvailableNetwork.findIndex((i) => i == Number(chainId)) !== -1
               ? Number(chainId)
               : "unknown",
         },

--- a/packages/webapp/src/hooks/useractions/useNFTWithdraw.ts
+++ b/packages/webapp/src/hooks/useractions/useNFTWithdraw.ts
@@ -97,7 +97,7 @@ export const useNFTWithdraw = <
     isAddressCheckLoading,
   } = useAddressCheck();
 
-  const isNotAvaiableAddress =
+  const isNotAvailableAddress =
     isCFAddress ||
     (isContractAddress &&
       disableWithdrawList.includes(nftWithdrawValue?.belong ?? ""));
@@ -115,7 +115,7 @@ export const useNFTWithdraw = <
         .lte(Number(nftWithdrawValue.nftBalance) ?? 0) &&
       addrStatus === AddressError.NoError &&
       !isFeeNotEnough &&
-      !isNotAvaiableAddress &&
+      !isNotAvailableAddress &&
       !!address
     ) {
       enableBtn();
@@ -133,7 +133,7 @@ export const useNFTWithdraw = <
     address,
     disableBtn,
     enableBtn,
-    isNotAvaiableAddress,
+    isNotAvailableAddress,
   ]);
 
   React.useEffect(() => {
@@ -143,7 +143,7 @@ export const useNFTWithdraw = <
     addrStatus,
     nftWithdrawValue.fee,
     nftWithdrawValue.tradeValue,
-    isNotAvaiableAddress,
+    isNotAvailableAddress,
   ]);
 
   const walletLayer2Callback = React.useCallback(() => {
@@ -457,7 +457,7 @@ export const useNFTWithdraw = <
     },
     addressDefault: address,
     accAddr: account.accAddress,
-    isNotAvaiableAddress,
+    isNotAvailableAddress,
     realAddr,
     disableWithdrawList,
     tradeData: nftWithdrawValue as any,

--- a/packages/webapp/src/hooks/useractions/useWithdraw.ts
+++ b/packages/webapp/src/hooks/useractions/useWithdraw.ts
@@ -95,7 +95,7 @@ export const useWithdraw = <R extends IBData<T>, T>() => {
     isAddressCheckLoading,
   } = useAddressCheck();
 
-  const isNotAvaiableAddress =
+  const isNotAvailableAddress =
     isCFAddress ||
     (isContractAddress &&
       disableWithdrawList.includes(withdrawValue?.belong ?? ""));
@@ -115,7 +115,7 @@ export const useWithdraw = <R extends IBData<T>, T>() => {
       if (
         tradeValue &&
         !exceedPoolLimit &&
-        !isNotAvaiableAddress &&
+        !isNotAvailableAddress &&
         chargeFeeTokenList.length &&
         !isFeeNotEnough &&
         withdrawValue.fee?.belong &&
@@ -141,7 +141,7 @@ export const useWithdraw = <R extends IBData<T>, T>() => {
     tokenMap,
     address,
     addrStatus,
-    isNotAvaiableAddress,
+    isNotAvailableAddress,
     chargeFeeTokenList,
     withdrawValue,
     isFeeNotEnough,
@@ -156,7 +156,7 @@ export const useWithdraw = <R extends IBData<T>, T>() => {
     withdrawValue?.fee,
     withdrawValue?.belong,
     withdrawValue?.tradeValue,
-    isNotAvaiableAddress,
+    isNotAvailableAddress,
   ]);
 
   const updateWithdrawTypes = React.useCallback(async () => {
@@ -511,7 +511,7 @@ export const useWithdraw = <R extends IBData<T>, T>() => {
     isContractAddress,
     withdrawI18nKey,
     accAddr: account.accAddress,
-    isNotAvaiableAddress,
+    isNotAvailableAddress,
     addressDefault: address,
     realAddr,
     disableWithdrawList,


### PR DESCRIPTION
I noticed that there were a few cases where the word available was misspelled in variable names / props.  Also, there was a case where the translation of labelAvaiable was referenced, which is not present in the translations.