### PR TITLE
Fix for issue 503: Update NFTPage/MyNFT/hook.ts

### DIFF
--- a/packages/common-resources/static-resources/src/constant/trade.ts
+++ b/packages/common-resources/static-resources/src/constant/trade.ts
@@ -136,7 +136,7 @@ export const PROPERTY_Value_LIMIT = 40;
 export const LOOPRING_TAKE_NFT_META_KET = {
   name: "name",
   image: "image",
-  royaltyPercentage: "royaltyPercentage",
+  royalty_percentage: "royalty_percentage",
   description: "description",
   properties: "properties",
 };

--- a/packages/webapp/src/pages/NFTPage/MyNFT/hook.ts
+++ b/packages/webapp/src/pages/NFTPage/MyNFT/hook.ts
@@ -100,6 +100,14 @@ export const useMyNFT = () => {
         const uri = IPFS_LOOPRING_SITE + cid;
         return fetch(uri)
           .then((response) => response.json())
+          .then((metaFromIpfs) => {
+            return Reflect.ownKeys(LOOPRING_TAKE_NFT_META_KET).reduce(
+              (prev, key) => {
+                return { ...prev, [key]: metaFromIpfs[key] };
+              },
+              {} as LOOPRING_NFT_METADATA
+            );
+          })
           .catch((error) => {
             return {};
           });


### PR DESCRIPTION
This PR intends to fix #503 and prevent injection of keys from the metadata.
Previous fix only addressed this issue for `DEPLOYED` NFT contracts.
The suspected reason that Loopring team wasn't able to reproduce while I was is that I my NFT contract isn't deployed, while their most likely is deployed.
Attached a video of the issue reproduced on loopring.io but fixed on locally-hosted webapp from master branch

https://user-images.githubusercontent.com/2715455/174717791-dabbde02-1dd0-4740-87d6-2ac55ac51e3b.mp4

This PR also fixes an issue where links for an NFT from the web wallet to explorer was invalid due to `royalty_percentage` being parsed incorrectly and thus being `undefined` (was parsed as `royaltyPercentage`, thanks @sk33z3r for the find)
Example of broken link: https://explorer.loopring.io/nft/0x1c65331556cff08bb06c56fbb68fb0d1d2194f8a-0-0x2aaab2766bc2ca0e530429146da29131caf273c2-0x1a8cb0e8bff469086cb4cf153bbf33c8cbf358fe2d5ba1c9c66bfc82225890e5-undefined
Versus the correct link: https://explorer.loopring.io/nft/0x1c65331556cff08bb06c56fbb68fb0d1d2194f8a-0-0x2aaab2766bc2ca0e530429146da29131caf273c2-0x1a8cb0e8bff469086cb4cf153bbf33c8cbf358fe2d5ba1c9c66bfc82225890e5-1

Although not able to verify, this issue would only happen on NFTs with deployed contracts and with metadata not cached by loopring.io
