### PR TITLE
Update subgraph url to maintained version

### DIFF
--- a/packages/common-resources/static-resources/src/constant/router.ts
+++ b/packages/common-resources/static-resources/src/constant/router.ts
@@ -371,7 +371,7 @@ export const FOOTER_LIST_MAP = {
     {
       linkName: "Subgraph", //Subgraph
       linkHref:
-        "https://thegraph.com/explorer/subgraph?id=HgnaENC2oG5hJFsWoHvULBbj7djTJ7TZnqa58iTWA3Rd",
+        "https://thegraph.com/explorer/subgraphs/7QP7oCLbEAjejkp7wSLTD1zbRMSiDydAmALksBB5E6i1",
     },
   ],
 };


### PR DESCRIPTION
The current link is outdated. This updates the subgraph link to the correct / currently maintained version