### PR TITLE
Fix Typographical Error in "Material-UI" and Correct Link  

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 <h2>Ethereum’s First zkRollup Layer2</h2>
 <p>Fast, Secure, and 100x Lower Fees</p>
 
-[![license](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Loopring/loopring-web-v2/master/LICENSE)
+[![license](https://img.shields.io/badge/license-MIT-blue)](https://github.com/Loopring/loopring-web-v2/blob/released/LICENSE)
 
 [![type-badge](https://img.shields.io/npm/types/react-data-grid)](https://www.npmjs.com/package/react-data-grid)
 
-<!-- [![Materi-UI](https://img.shields.io/npm/types/react-data-grid)](https://www.npmjs.com/package/react-data-grid) -->
+<!-- [![Material-UI](https://img.shields.io/npm/types/react-data-grid)](https://www.npmjs.com/package/react-data-grid) -->
 
 </div>
 


### PR DESCRIPTION
1. Fixes a typographical error, changing "Materi-UI" to "Material-UI".  
2. Corrects a broken or outdated link in the documentation.  

## Changes Made  

1. **Typographical Error Fix:**  
   - Updated "Materi-UI" to "Material-UI" in the relevant section for improved accuracy and consistency.  

2. **Link Correction:**  
   - Replaced the incorrect link with the correct one to ensure proper navigation.  

### Before  
![image](https://github.com/user-attachments/assets/8c2d8ad6-aa00-4415-a9c8-5cf00d7bb0ac)  

### After  
![image](https://github.com/user-attachments/assets/de03c7c7-8d72-4ae0-a42d-468a54d578ca)  
